### PR TITLE
fixed backbutton on recipeshowpane to navigate to recipes index

### DIFF
--- a/app/javascript/react/containers/RecipeShowContainer.js
+++ b/app/javascript/react/containers/RecipeShowContainer.js
@@ -229,7 +229,7 @@ class RecipeShowContainer extends Component {
     if (this.state.readOnly){
       showPane=
       <div className="recipe-show-pane">
-        <a href="/">
+        <a href="/recipes">
           <button className="variation-button" >
             Back to Recipes
           </button>


### PR DESCRIPTION
fixed back button on recipe show page so it no longer navigates to the root. This fixes a bug that was introduced when the splash page was added